### PR TITLE
force http-01

### DIFF
--- a/services/letsencrypt.md
+++ b/services/letsencrypt.md
@@ -9,7 +9,9 @@ appliance first the following manual steps are required.
 * On the virtual machine run 
 ```bash
 systemctl stop nginx.service
-certbot certonly --standalone
+systemctl start apache2.service
+certbot certonly --webroot -w /var/www/html -d cicognara.org
+systemctl stop apache2.service
 systemctl start nginx.service
 ```
 * copy the latest downloaded `cert.pem` and `privkey.pem` to a place you can


### PR DESCRIPTION
By default certbot will use the tls-sni-01 method of verification, which won’t work behind a proxy.